### PR TITLE
(회원, 팀) 이름 중복제한 및 검증, 이름기반 검색 기능 추가 

### DIFF
--- a/withSpace/build.gradle
+++ b/withSpace/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     // s3관련 의존성
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+    //유사도 알고리즘 관련 라이브러리
+    implementation 'org.apache.commons:commons-text:1.10.0'
+
 }
 
 tasks.named('test') {

--- a/withSpace/src/main/java/hansung/cse/withSpace/config/auth/CustomUserDetailsService.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/config/auth/CustomUserDetailsService.java
@@ -2,7 +2,7 @@
 //
 //import hansung.cse.withSpace.domain.Member;
 //import hansung.cse.withSpace.exception.member.MemberNotFoundException;
-//import hansung.cse.withSpace.repository.MemberRepository;
+//import hansung.cse.withSpace.repository.member.MemberRepository;
 //import hansung.cse.withSpace.service.MemberService;
 //import lombok.RequiredArgsConstructor;
 //import org.springframework.beans.factory.annotation.Autowired;

--- a/withSpace/src/main/java/hansung/cse/withSpace/config/auth/GoogleOauth2UserService.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/config/auth/GoogleOauth2UserService.java
@@ -1,7 +1,7 @@
 package hansung.cse.withSpace.config.auth;
 
 import hansung.cse.withSpace.domain.Member;
-import hansung.cse.withSpace.repository.MemberRepository;
+import hansung.cse.withSpace.repository.member.MemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;

--- a/withSpace/src/main/java/hansung/cse/withSpace/config/jwt/JwtAuthenticationSuccessHandler.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/config/jwt/JwtAuthenticationSuccessHandler.java
@@ -2,7 +2,7 @@ package hansung.cse.withSpace.config.jwt;
 
 import hansung.cse.withSpace.config.jwt.JwtTokenUtil;
 import hansung.cse.withSpace.domain.Member;
-import hansung.cse.withSpace.repository.MemberRepository;
+import hansung.cse.withSpace.repository.member.MemberRepository;
 import hansung.cse.withSpace.service.MemberService;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/withSpace/src/main/java/hansung/cse/withSpace/controller/MemberController.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/controller/MemberController.java
@@ -4,11 +4,9 @@ import hansung.cse.withSpace.domain.Member;
 import hansung.cse.withSpace.requestdto.member.MemberJoinRequestDto;
 import hansung.cse.withSpace.requestdto.member.MemberUpdateRequestDto;
 import hansung.cse.withSpace.responsedto.BasicResponse;
-import hansung.cse.withSpace.responsedto.member.GetMemberResponseDto;
-import hansung.cse.withSpace.responsedto.member.JoinMemberResponse;
-import hansung.cse.withSpace.responsedto.member.MemberBasicResponse;
-import hansung.cse.withSpace.responsedto.member.UpdateMemberResponse;
+import hansung.cse.withSpace.responsedto.member.*;
 import hansung.cse.withSpace.responsedto.space.MemberSpaceDto;
+import hansung.cse.withSpace.responsedto.team.TeamSearchByNameDto;
 import hansung.cse.withSpace.service.MemberService;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,6 +23,7 @@ import org.springframework.security.web.authentication.logout.SecurityContextLog
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Optional;
 
 @RestController
@@ -50,6 +49,17 @@ public class MemberController {
         Member member = memberService.findOne(memberId);
         GetMemberResponseDto getMemberResponseDto = new GetMemberResponseDto(member);
         BasicResponse basicResponse = new BasicResponse<>(1, "회원 조회 성공", getMemberResponseDto);
+        return new ResponseEntity<>(basicResponse, HttpStatus.OK);
+    }
+
+    @GetMapping("/member/name") //이름으로 회원 조회
+    public ResponseEntity<BasicResponse> getMembersByName(@RequestParam String memberName,
+                                                          @RequestParam(defaultValue = "10") int limit) {
+        //Member member = memberService.searchMemberByName(memberName);
+        List<MemberSearchByNameDto> getMemberResponseDto = memberService.searchMembersByName(memberName, limit);
+
+        BasicResponse basicResponse = new BasicResponse<>(1, "회원 조회 성공", getMemberResponseDto);
+        //BasicResponse basicResponse = new BasicResponse<>(1, "회원 조회 성공", null);
         return new ResponseEntity<>(basicResponse, HttpStatus.OK);
     }
 

--- a/withSpace/src/main/java/hansung/cse/withSpace/controller/TeamController.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/controller/TeamController.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Optional;
@@ -33,7 +34,7 @@ public class TeamController {
     private final MemberService memberService;
 
     @PostMapping("/team") //팀생성
-    public ResponseEntity<CreateTeamResponse> createTeam(@RequestBody CreateTeamRequestDto teamRequest) {
+    public ResponseEntity<CreateTeamResponse> createTeam(@Validated @RequestBody CreateTeamRequestDto teamRequest) {
         Member member = memberService.findOne(teamRequest.getMemberId());
         Long teamId = teamService.makeTeam(member, teamRequest.getTeamName());
         CreateTeamResponse createTeamResponse = new CreateTeamResponse(teamId, CREATED, "팀 생성 완료");

--- a/withSpace/src/main/java/hansung/cse/withSpace/controller/TeamController.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/controller/TeamController.java
@@ -13,6 +13,7 @@ import hansung.cse.withSpace.responsedto.space.MemberSpaceDto;
 import hansung.cse.withSpace.responsedto.space.TeamSpaceDto;
 import hansung.cse.withSpace.responsedto.team.CreateTeamResponse;
 import hansung.cse.withSpace.responsedto.team.TeamListDto;
+import hansung.cse.withSpace.responsedto.team.TeamSearchByNameDto;
 import hansung.cse.withSpace.service.MemberService;
 import hansung.cse.withSpace.service.TeamService;
 import jakarta.persistence.EntityNotFoundException;
@@ -23,6 +24,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Optional;
 
 @RestController
@@ -66,6 +68,26 @@ public class TeamController {
         return new ResponseEntity<>(basicResponse, HttpStatus.CREATED);
 
     }
+
+    @GetMapping("/team/name")
+    public ResponseEntity<BasicResponse> getTeamByName(@RequestParam String teamName,
+                                             @RequestParam(defaultValue = "10") int limit) {
+        List<TeamSearchByNameDto> teamListDto= teamService.searchTeamsByName(teamName, limit);
+        BasicResponse basicResponse = new BasicResponse(1, "팀 조회 성공", teamListDto);
+        return new ResponseEntity<>(basicResponse, HttpStatus.CREATED);
+    }
+
+//    @GetMapping("/team/name/{teamName}") //팀 이름으로 조회
+//    public ResponseEntity<BasicResponse> getTeamByName(@PathVariable String teamName) {
+//        Team team = teamService.searchTeamByName(teamName);
+//
+//        TeamListDto teamListDto = new TeamListDto(team);
+//
+//        BasicResponse basicResponse = new BasicResponse(1, "팀 조회 성공", teamListDto);
+//
+//        return new ResponseEntity<>(basicResponse, HttpStatus.OK);
+//
+//    }
 
     @GetMapping("/team/{teamId}/space") //팀 스페이스 조회
     @PreAuthorize("@customSecurityUtil.isMemberInTeam(#teamId)") // 현재 로그인한 사용자가 team에 가입되어있는 경우에만 접근 허용

--- a/withSpace/src/main/java/hansung/cse/withSpace/domain/Member.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/domain/Member.java
@@ -40,6 +40,8 @@ public class Member {   //회원
     @Column(unique = true)
     private String email;
     private String password;
+
+    @Column(unique = true)
     private String memberName;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/withSpace/src/main/java/hansung/cse/withSpace/domain/Team.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/domain/Team.java
@@ -28,6 +28,7 @@ public class Team {
 
     private int memberCount;
 
+    @Column(unique = true)
     private String teamName;
 
     private Long host;

--- a/withSpace/src/main/java/hansung/cse/withSpace/repository/MemberRepository.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/repository/MemberRepository.java
@@ -15,5 +15,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
 
+    Optional<Member> findByMemberName(String memberName);
+
     boolean existsByEmail(String email); //이메일 중복검사시 사용
 }

--- a/withSpace/src/main/java/hansung/cse/withSpace/repository/TeamRepository.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/repository/TeamRepository.java
@@ -4,8 +4,11 @@ import hansung.cse.withSpace.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
+    Optional<Team> findByTeamName(String teamName);
 
 }

--- a/withSpace/src/main/java/hansung/cse/withSpace/repository/member/MemberRepository.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/repository/member/MemberRepository.java
@@ -1,10 +1,11 @@
-package hansung.cse.withSpace.repository;
+package hansung.cse.withSpace.repository.member;
 
 import hansung.cse.withSpace.domain.Member;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,4 +19,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByMemberName(String memberName);
 
     boolean existsByEmail(String email); //이메일 중복검사시 사용
+
+    List<Member> searchMembersByName(String query, int limit);
 }

--- a/withSpace/src/main/java/hansung/cse/withSpace/repository/member/MemberRepositoryCustom.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/repository/member/MemberRepositoryCustom.java
@@ -1,0 +1,11 @@
+package hansung.cse.withSpace.repository.member;
+
+
+
+import hansung.cse.withSpace.domain.Member;
+
+import java.util.List;
+
+public interface MemberRepositoryCustom {
+    List<Member> searchMembersByName(String query, int limit);
+}

--- a/withSpace/src/main/java/hansung/cse/withSpace/repository/member/MemberRepositoryImpl.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/repository/member/MemberRepositoryImpl.java
@@ -1,0 +1,31 @@
+package hansung.cse.withSpace.repository.member;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import hansung.cse.withSpace.domain.Member;
+import hansung.cse.withSpace.domain.QMember;
+import hansung.cse.withSpace.domain.QTeam;
+import hansung.cse.withSpace.domain.Team;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.List;
+
+public class MemberRepositoryImpl  extends QuerydslRepositorySupport implements MemberRepositoryCustom{
+
+    public MemberRepositoryImpl() {
+        super(Member.class);
+    }
+
+    @Override
+    public List<Member> searchMembersByName(String query, int limit) {
+        QMember member = QMember.member;
+
+
+        JPAQuery<Member> jpaQuery = new JPAQuery<>(getEntityManager());
+        List<Member> results = jpaQuery.from(member)
+                .orderBy(member.memberName.asc())
+                .fetch();
+
+        return results;
+    }
+
+}

--- a/withSpace/src/main/java/hansung/cse/withSpace/repository/team/TeamRepository.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/repository/team/TeamRepository.java
@@ -1,9 +1,10 @@
-package hansung.cse.withSpace.repository;
+package hansung.cse.withSpace.repository.team;
 
 import hansung.cse.withSpace.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +12,5 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 
     Optional<Team> findByTeamName(String teamName);
 
+    List<Team> searchTeamsByName(String query, int limit);
 }

--- a/withSpace/src/main/java/hansung/cse/withSpace/repository/team/TeamRepositoryCustom.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/repository/team/TeamRepositoryCustom.java
@@ -1,0 +1,9 @@
+package hansung.cse.withSpace.repository.team;
+
+import hansung.cse.withSpace.domain.Team;
+
+import java.util.List;
+
+public interface TeamRepositoryCustom {
+    List<Team> searchTeamsByName(String query, int limit);
+}

--- a/withSpace/src/main/java/hansung/cse/withSpace/repository/team/TeamRepositoryImpl.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/repository/team/TeamRepositoryImpl.java
@@ -1,0 +1,31 @@
+package hansung.cse.withSpace.repository.team;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import hansung.cse.withSpace.domain.QTeam;
+import hansung.cse.withSpace.domain.Team;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.List;
+
+public class TeamRepositoryImpl extends QuerydslRepositorySupport implements TeamRepositoryCustom {
+
+    public TeamRepositoryImpl() {
+        super(Team.class);
+    }
+
+    @Override
+    public List<Team> searchTeamsByName(String query, int limit) {
+        QTeam team = QTeam.team;
+
+
+        JPAQuery<Team> jpaQuery = new JPAQuery<>(getEntityManager());
+        List<Team> results = jpaQuery.from(team)
+                .orderBy(team.teamName.asc())
+                .fetch();
+
+        return results;
+    }
+
+
+}

--- a/withSpace/src/main/java/hansung/cse/withSpace/requestdto/member/MemberJoinRequestDto.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/requestdto/member/MemberJoinRequestDto.java
@@ -1,5 +1,6 @@
 package hansung.cse.withSpace.requestdto.member;
 
+import hansung.cse.withSpace.validation.member.UniqueMemberName;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -15,6 +16,7 @@ public class MemberJoinRequestDto {
     private String email;
 
     @NotEmpty(message = "이름을 입력해주세요.")
+    @UniqueMemberName
     private String memberName;
 
     @NotEmpty(message = "비밀번호를 입력해주세요.")

--- a/withSpace/src/main/java/hansung/cse/withSpace/requestdto/team/CreateTeamRequestDto.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/requestdto/team/CreateTeamRequestDto.java
@@ -1,5 +1,6 @@
 package hansung.cse.withSpace.requestdto.team;
 
+import hansung.cse.withSpace.validation.team.UniqueTeamName;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,5 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CreateTeamRequestDto {
     private Long memberId;
+
+    @UniqueTeamName
     private String teamName;
 }

--- a/withSpace/src/main/java/hansung/cse/withSpace/responsedto/member/MemberSearchByNameDto.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/responsedto/member/MemberSearchByNameDto.java
@@ -1,0 +1,12 @@
+package hansung.cse.withSpace.responsedto.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MemberSearchByNameDto {
+    private Long memberId;
+    private String memberName;
+
+}

--- a/withSpace/src/main/java/hansung/cse/withSpace/responsedto/team/TeamSearchByNameDto.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/responsedto/team/TeamSearchByNameDto.java
@@ -1,0 +1,12 @@
+package hansung.cse.withSpace.responsedto.team;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+@AllArgsConstructor
+public class TeamSearchByNameDto {
+    private Long teamId;
+    private String teamName;
+}

--- a/withSpace/src/main/java/hansung/cse/withSpace/service/BlockService.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/service/BlockService.java
@@ -1,23 +1,16 @@
 package hansung.cse.withSpace.service;
 
 import hansung.cse.withSpace.exception.block.BlockNotFoundException;
-import hansung.cse.withSpace.exception.member.MemberNotFoundException;
-import hansung.cse.withSpace.exception.page.PageNotFoundException;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import hansung.cse.withSpace.domain.Member;
 import hansung.cse.withSpace.domain.space.Page;
 import hansung.cse.withSpace.domain.space.Block;
 import hansung.cse.withSpace.repository.BlockRepository;
-import hansung.cse.withSpace.repository.MemberRepository;
-import hansung.cse.withSpace.repository.PageRepository;
 import hansung.cse.withSpace.requestdto.space.page.block.BlockUpdateRequestDto;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)

--- a/withSpace/src/main/java/hansung/cse/withSpace/service/MemberService.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/service/MemberService.java
@@ -1,28 +1,25 @@
 package hansung.cse.withSpace.service;
 
 import hansung.cse.withSpace.domain.Member;
-import hansung.cse.withSpace.domain.space.MemberSpace;
-import hansung.cse.withSpace.domain.space.Page;
+import hansung.cse.withSpace.domain.Team;
 import hansung.cse.withSpace.domain.space.Space;
-import hansung.cse.withSpace.domain.space.schedule.Schedule;
 import hansung.cse.withSpace.exception.member.MemberNotFoundException;
-import hansung.cse.withSpace.exception.member.MemberUpdateException;
 import hansung.cse.withSpace.exception.member.join.DuplicateEmailException;
-import hansung.cse.withSpace.repository.MemberRepository;
-import hansung.cse.withSpace.repository.PageRepository;
-import hansung.cse.withSpace.repository.ScheduleRepository;
-import hansung.cse.withSpace.repository.SpaceRepository;
+
+import hansung.cse.withSpace.repository.member.MemberRepository;
 import hansung.cse.withSpace.requestdto.member.MemberJoinRequestDto;
 import hansung.cse.withSpace.requestdto.member.MemberUpdateRequestDto;
 import hansung.cse.withSpace.requestdto.space.page.PageCreateRequestDto;
-import jakarta.persistence.EntityNotFoundException;
+import hansung.cse.withSpace.responsedto.member.MemberSearchByNameDto;
+import hansung.cse.withSpace.responsedto.team.TeamSearchByNameDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.apache.commons.text.similarity.JaroWinklerDistance;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.Optional;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -116,4 +113,57 @@ public class MemberService {
     }
 
 
+    public synchronized List<MemberSearchByNameDto> searchMembersByName(String query, int limit) {
+        List<Member> members = memberRepository.searchMembersByName(query, limit);
+
+        JaroWinklerDistance jaroWinkler = new JaroWinklerDistance();
+
+        List<MemberSearchByNameDto> memberDTOs = members.stream()
+                .map(member -> new MemberSearchByNameDto(member.getId(), member.getMemberName()))
+                .sorted((member1, member2) -> {
+                    // 정확한 일치를 최우선 순위로 정렬
+                    boolean exactMatch1 = member1.getMemberName().equalsIgnoreCase(query);
+                    boolean exactMatch2 = member2.getMemberName().equalsIgnoreCase(query);
+
+                    if (exactMatch1 != exactMatch2) {
+                        return exactMatch1 ? -1 : 1;
+                    }
+
+                    // 검색어에 포함된 단어의 빈도를 기준으로 정렬
+                    String[] queryWords = query.toLowerCase().split(" ");
+                    long count1 = Arrays.stream(queryWords).filter(word -> member1.getMemberName().toLowerCase().contains(word)).count();
+                    long count2 = Arrays.stream(queryWords).filter(word -> member2.getMemberName().toLowerCase().contains(word)).count();
+
+                    if (count1 != count2) {
+                        return Long.compare(count2, count1);
+                    }
+
+                    // 검색어에 포함된 문자와 숫자를 개별적으로 확인하여 일치하는 경우 가중치 부여
+                    int weight1 = 0;
+                    int weight2 = 0;
+
+                    for (char c : query.toCharArray()) {
+                        if (member1.getMemberName().toLowerCase().contains(String.valueOf(c))) {
+                            weight1++;
+                        }
+                        if (member2.getMemberName().toLowerCase().contains(String.valueOf(c))) {
+                            weight2++;
+                        }
+                    }
+
+                    if (weight1 != weight2) {
+                        return Integer.compare(weight2, weight1);
+                    }
+
+                    // Jaro-Winkler 유사도를 기준으로 정렬
+                    double similarity1 = jaroWinkler.apply(query, member1.getMemberName());
+                    double similarity2 = jaroWinkler.apply(query, member2.getMemberName());
+
+                    return Double.compare(similarity2, similarity1);
+                })
+                .limit(limit)
+                .collect(Collectors.toList());
+
+        return memberDTOs;
+    }
 }

--- a/withSpace/src/main/java/hansung/cse/withSpace/service/RoomService.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/service/RoomService.java
@@ -9,7 +9,7 @@ import hansung.cse.withSpace.exception.chat.RoomNotFoundException;
 import hansung.cse.withSpace.exception.friend.NotFriendException;
 import hansung.cse.withSpace.exception.member.MemberNotFoundException;
 import hansung.cse.withSpace.repository.FriendShipRepository;
-import hansung.cse.withSpace.repository.MemberRepository;
+import hansung.cse.withSpace.repository.member.MemberRepository;
 import hansung.cse.withSpace.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/withSpace/src/main/java/hansung/cse/withSpace/validation/member/UniqueMemberName.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/validation/member/UniqueMemberName.java
@@ -1,0 +1,19 @@
+package hansung.cse.withSpace.validation.member;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = UniqueMemberNameValidator.class)
+public @interface UniqueMemberName {
+    String message() default "이미 존재하는 닉네임입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/withSpace/src/main/java/hansung/cse/withSpace/validation/member/UniqueMemberNameValidator.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/validation/member/UniqueMemberNameValidator.java
@@ -1,7 +1,7 @@
 package hansung.cse.withSpace.validation.member;
 
 import hansung.cse.withSpace.domain.Member;
-import hansung.cse.withSpace.repository.MemberRepository;
+import hansung.cse.withSpace.repository.member.MemberRepository;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import lombok.RequiredArgsConstructor;

--- a/withSpace/src/main/java/hansung/cse/withSpace/validation/member/UniqueMemberNameValidator.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/validation/member/UniqueMemberNameValidator.java
@@ -1,0 +1,24 @@
+package hansung.cse.withSpace.validation.member;
+
+import hansung.cse.withSpace.domain.Member;
+import hansung.cse.withSpace.repository.MemberRepository;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class UniqueMemberNameValidator implements ConstraintValidator<UniqueMemberName, Object> {
+    private final MemberRepository memberRepository;
+    @Override
+    public void initialize(UniqueMemberName constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+    @Override
+    public boolean isValid(Object value, ConstraintValidatorContext context) {
+        String memberName = (String) value;
+        Optional<Member> member = memberRepository.findByMemberName(memberName);
+        return member.isEmpty();
+    }
+}

--- a/withSpace/src/main/java/hansung/cse/withSpace/validation/team/UniqueTeamName.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/validation/team/UniqueTeamName.java
@@ -1,0 +1,19 @@
+package hansung.cse.withSpace.validation.team;
+
+import hansung.cse.withSpace.validation.member.UniqueMemberNameValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = UniqueTeamNameValidator.class)
+public @interface UniqueTeamName {
+    String message() default "이미 존재하는 팀 이름입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/withSpace/src/main/java/hansung/cse/withSpace/validation/team/UniqueTeamNameValidator.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/validation/team/UniqueTeamNameValidator.java
@@ -1,0 +1,27 @@
+package hansung.cse.withSpace.validation.team;
+
+import hansung.cse.withSpace.domain.Team;
+import hansung.cse.withSpace.repository.TeamRepository;
+import hansung.cse.withSpace.validation.member.UniqueMemberName;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class UniqueTeamNameValidator implements ConstraintValidator<UniqueTeamName, Object> {
+
+    private final TeamRepository teamRepository;
+    @Override
+    public void initialize(UniqueTeamName constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Object value, ConstraintValidatorContext context) {
+        String teamName = (String) value;
+        Optional<Team> team = teamRepository.findByTeamName(teamName);
+        return team.isEmpty();
+    }
+}

--- a/withSpace/src/main/java/hansung/cse/withSpace/validation/team/UniqueTeamNameValidator.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/validation/team/UniqueTeamNameValidator.java
@@ -1,8 +1,7 @@
 package hansung.cse.withSpace.validation.team;
 
 import hansung.cse.withSpace.domain.Team;
-import hansung.cse.withSpace.repository.TeamRepository;
-import hansung.cse.withSpace.validation.member.UniqueMemberName;
+import hansung.cse.withSpace.repository.team.TeamRepository;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION

- Member와 Team 엔티티의 이름(memberName, teamName) 필드에 유니크 제약조건 추가 
- 이름 관련 중복 검증로직 추가 - UniqueMemberName, UniqueTeamName annotation 만들어줌 


-  회원, 팀 이름을 통한 검색 api 추가 
알고리즘 라이브러리 사용하여 최대한 개선함  
![image](https://user-images.githubusercontent.com/102939057/236911388-6a373b21-e1fb-4429-b285-546734461409.png)
![image](https://user-images.githubusercontent.com/102939057/236911447-b3870a85-c306-47a3-962c-d1c609742429.png)


