### PR TITLE
웹소켓 heartbeat로 status 변경 

### DIFF
--- a/withSpace/build.gradle
+++ b/withSpace/build.gradle
@@ -65,6 +65,9 @@ dependencies {
     implementation 'org.webjars:sockjs-client:1.0.2'
     implementation 'org.webjars:stomp-websocket:2.3.3'
 
+    //Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/withSpace/src/main/java/hansung/cse/withSpace/TestDB.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/TestDB.java
@@ -56,9 +56,9 @@
 //    @PostConstruct
 //    public void postConstruct() {
 //        scheduleInit();
-//        friendInit();
-//        teamInit();
-//        pageInit();
+//        //friendInit();
+//        //teamInit();
+//        //pageInit();
 //    }
 //
 //
@@ -156,8 +156,8 @@
 //
 //        Schedule schedule = memberD.getMemberSpace().getSchedule();
 //
-//        Category studyCategory = new Category(schedule, new CategoryRequestDto("공부", PublicSetting.PUBLIC, 1));
-//        Category workOutCategory = new Category(schedule, new CategoryRequestDto("운동", PublicSetting.PRIVATE, 2));
+//        Category studyCategory = new Category(schedule, new CategoryRequestDto("공부", PublicSetting.PUBLIC, ""));
+//        Category workOutCategory = new Category(schedule, new CategoryRequestDto("운동", PublicSetting.PRIVATE, ""));
 //
 //        categoryService.makeCategory(studyCategory);
 //        categoryService.makeCategory(workOutCategory);

--- a/withSpace/src/main/java/hansung/cse/withSpace/WithSpaceApplication.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/WithSpaceApplication.java
@@ -2,8 +2,10 @@ package hansung.cse.withSpace;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class WithSpaceApplication {
 
 	public static void main(String[] args) {

--- a/withSpace/src/main/java/hansung/cse/withSpace/config/RedisConfig.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package hansung.cse.withSpace.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/withSpace/src/main/java/hansung/cse/withSpace/config/RedisConfig.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/config/RedisConfig.java
@@ -23,10 +23,5 @@ public class RedisConfig {
     }
 
 
-    @Bean
-    public RedisTemplate<?, ?> redisTemplate() {
-        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
-        return redisTemplate;
-    }
+
 }

--- a/withSpace/src/main/java/hansung/cse/withSpace/config/jwt/JwtAuthenticationFilter.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/config/jwt/JwtAuthenticationFilter.java
@@ -157,6 +157,24 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         throw new TokenInvalidateException("토큰이 유효하지 않습니다.");
     }
 
+    public UUID getUUIDFromToken(String token) {
+
+        if (token != null && jwtTokenUtil.validateToken(token)) {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(jwtTokenUtil.getSigningKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            String uuidString = claims.get("UUID", String.class);
+            UUID uuid = UUID.fromString(uuidString);
+            System.out.println("uuid = " + uuid);
+            return uuid;
+        }
+        throw new TokenInvalidateException("토큰이 유효하지 않습니다.2");
+    }
+
+
     public boolean checkUUID(HttpServletRequest request, Long memberId) {
 
         //토큰의 uuid와 DB상 회원의 uuid가 일치하는지 검사

--- a/withSpace/src/main/java/hansung/cse/withSpace/config/jwt/JwtTokenUtil.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/config/jwt/JwtTokenUtil.java
@@ -52,8 +52,7 @@ public class JwtTokenUtil {
 
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         Member member = memberService.findByEmail(userDetails.getUsername()); // 로그인한 유저의 회원 정보를 가져옴
-        //Date now = new Date();
-        //Date expiryDate = new Date(now.getTime() + expiration)
+
 
 
         //로그인시마다 이전토큰 무효화
@@ -72,8 +71,6 @@ public class JwtTokenUtil {
                 .signWith(getSigningKey(), SignatureAlgorithm.HS512) //서명
                 .compact();
     }
-
-
 
 
     public String getUsernameFromToken(String token) {

--- a/withSpace/src/main/java/hansung/cse/withSpace/config/websocket/StompHandler.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/config/websocket/StompHandler.java
@@ -1,6 +1,8 @@
 package hansung.cse.withSpace.config.websocket;
 
+import hansung.cse.withSpace.config.jwt.JwtAuthenticationFilter;
 import hansung.cse.withSpace.config.jwt.JwtTokenUtil;
+import hansung.cse.withSpace.domain.Member;
 import hansung.cse.withSpace.exception.jwt.TokenInvalidateException;
 import hansung.cse.withSpace.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandlingException;
@@ -21,6 +24,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -28,7 +32,9 @@ import java.util.Objects;
 public class StompHandler implements ChannelInterceptor {
     private final Logger log = LoggerFactory.getLogger(this.getClass());
     private final JwtTokenUtil jwtTokenUtil;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final MemberService memberService;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -41,13 +47,31 @@ public class StompHandler implements ChannelInterceptor {
         log.info("헤더 : " + message.getHeaders());
         log.info("토큰 = " + accessor.getFirstNativeHeader("Authorization"));
 
-        if (StompCommand.CONNECT.equals(accessor.getCommand()) &&
-                !jwtTokenUtil.validateToken(Objects.requireNonNull(accessor.getFirstNativeHeader("Authorization"))
-                        .substring(7))) {
-            throw new TokenInvalidateException("웹소켓 before handshake - 토큰이 유효하지 않습니다.");
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+
+            String token = Objects.requireNonNull(accessor.getFirstNativeHeader("Authorization"))
+                    .substring(7);
+
+            UUID uuid = jwtAuthenticationFilter.getUUIDFromToken(token);
+            memberService.setMemberActive(uuid);
+            //세션 정보 Redis에 저장
+            String sessionId = accessor.getSessionId();
+            String sessionKey = "session:" + sessionId;
+            redisTemplate.opsForHash().put(sessionKey, "memberUUID", uuid);
+            log.info("Session stored in Redis - sessionId: {}, userId: {}", sessionId, uuid);
+        }
+        else if (StompCommand.DISCONNECT.equals(accessor.getCommand())) {
+
+
+
+
+
         }
 
         return message;
 
     }
+
+
+
 }

--- a/withSpace/src/main/java/hansung/cse/withSpace/config/websocket/WebSocketConfig.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/config/websocket/WebSocketConfig.java
@@ -40,7 +40,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
 
     private final StompHandler stompHandler;
-    //private final CustomHandshakeInterceptor handshakeInterceptor;
 
     final Logger log = LoggerFactory.getLogger(this.getClass());
 
@@ -57,18 +56,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws")
-                .setAllowedOrigins("*");
 
         registry.addEndpoint("/ws")
                 .setAllowedOrigins("*")
-                //.addInterceptors(handshakeInterceptor)
                 .withSockJS();
-
-//        registry.addEndpoint("/ws").
-//                setAllowedOrigins("http://localhost:3000").
-//                withSockJS();
-
 
         registry.addEndpoint("/ws")
                 .setAllowedOrigins("http://localhost:3000")
@@ -76,99 +67,5 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     }
 
-
-
-//    @Override
-//    public void configureMessageBroker(MessageBrokerRegistry config) {
-//        // 메시지를 발행할 토픽 주소 설정
-//        // 메시지 구독 요청 url -> 메시지 받을 때
-//        config.enableSimpleBroker("/topic");
-//
-//        // 메시지 발행 요청 url -> 메시지 보낼 때
-//        // 클라이언트에서 메시지를 보낼 주소 prefix 설정
-//        config.setApplicationDestinationPrefixes("/app");
-//    }
-//
-
-//    @Override
-//    public void configureClientInboundChannel(ChannelRegistration registration) {
-//
-//        registration.interceptors(new ChannelInterceptor() {
-//            @Override
-//            public Message<?> preSend(Message<?> message, MessageChannel channel) {
-//
-//                StompHeaderAccessor accessor =
-//                        MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-//                if (StompCommand.CONNECT.equals(accessor.getCommand())) {
-//                    List<String> authorization = accessor.getNativeHeader("JWT-Authorization");
-//                    if (authorization != null && authorization.size() > 0) {
-//                        String authToken = authorization.get(0).substring(7);
-//                        String username = jwtTokenUtil.getUsernameFromToken(authToken);
-//
-//                        if (username != null && jwtTokenUtil.validateToken(authToken)) {
-//
-//                            UserDetails userDetails = myMemberDetailService.getUserDetailsByEmail(username);
-//
-//                            UsernamePasswordAuthenticationToken user =
-//                                    new UsernamePasswordAuthenticationToken(
-//                                            userDetails, null, userDetails.getAuthorities());
-//                            accessor.setUser(user);
-//                        }
-//                        else{
-//                            log.error(authToken);
-//                        }
-//                    }
-//                }
-//                return message;
-//            }
-//        });
-//    }
-
-
-//    @Override
-//    public void configureClientInboundChannel(ChannelRegistration registration) {
-//        registration.interceptors(stompHandler);
-//    }
-//
-//
-//    @Override
-//    public void registerStompEndpoints(StompEndpointRegistry registry) {
-//        registry.addEndpoint("/ws")
-//                .setAllowedOrigins("*");
-//
-//        registry.addEndpoint("/ws")
-//                .setAllowedOrigins("*")
-////                .setHandshakeHandler(new DefaultHandshakeHandler() {
-////                    @Override
-////                    protected Principal determineUser(ServerHttpRequest request, WebSocketHandler wsHandler, Map<String, Object> attributes) {
-////                        // 이 부분에서 Spring Session의 HTTP 세션을 통해 로그인된 사용자를 가져옴
-////                        // Spring Session이 HTTP와 WebSocket 세션을 자동으로 동기화하므로
-////                        // HTTP 세션에서 가져온 사용자 정보를 그대로 WebSocket 세션에서 사용할 수 있음
-////                        System.out.println("test - - - - -");
-////                        return super.determineUser(request, wsHandler, attributes);
-////                    }
-////                })
-//                .withSockJS();
-//
-//        registry.addEndpoint("/ws").
-//                setAllowedOrigins("http://localhost:3000").
-//                withSockJS();
-//
-//
-//        registry.addEndpoint("/ws")
-//                .setAllowedOrigins("http://localhost:3000")
-////                .setHandshakeHandler(new DefaultHandshakeHandler() {
-////                    @Override
-////                    protected Principal determineUser(ServerHttpRequest request, WebSocketHandler wsHandler, Map<String, Object> attributes) {
-////                        // 이 부분에서 Spring Session의 HTTP 세션을 통해 로그인된 사용자를 가져옴
-////                        // Spring Session이 HTTP와 WebSocket 세션을 자동으로 동기화하므로
-////                        // HTTP 세션에서 가져온 사용자 정보를 그대로 WebSocket 세션에서 사용할 수 있음
-////                        System.out.println("test - - - - -");
-////                        return super.determineUser(request, wsHandler, attributes);
-////                    }
-////                })
-//                .withSockJS();
-//
-//    }
 
 }

--- a/withSpace/src/main/java/hansung/cse/withSpace/config/websocket/WebSocketConfig.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/config/websocket/WebSocketConfig.java
@@ -65,9 +65,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 //.addInterceptors(handshakeInterceptor)
                 .withSockJS();
 
-        registry.addEndpoint("/ws").
-                setAllowedOrigins("http://localhost:3000").
-                withSockJS();
+//        registry.addEndpoint("/ws").
+//                setAllowedOrigins("http://localhost:3000").
+//                withSockJS();
 
 
         registry.addEndpoint("/ws")

--- a/withSpace/src/main/java/hansung/cse/withSpace/controller/WebSocketController.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/controller/WebSocketController.java
@@ -1,5 +1,8 @@
 package hansung.cse.withSpace.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import hansung.cse.withSpace.config.auth.MyMemberDetailService;
 import hansung.cse.withSpace.config.jwt.JwtAuthenticationFilter;
 import hansung.cse.withSpace.domain.Member;
@@ -11,14 +14,26 @@ import hansung.cse.withSpace.service.RoomService;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.socket.WebSocketSession;
 
 import java.security.Principal;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,7 +45,11 @@ public class WebSocketController {
     private final MemberService memberService;
     final Logger log = LoggerFactory.getLogger(this.getClass());
 
-    @MessageMapping("/{roomId}/message/{memberId}")
+    //private final RedisTemplate<String, Object> redisTemplate;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @MessageMapping("/{roomId}/message/{memberId}") // 채팅 메시지
     public void SendTemplateMessage(@Payload String message, @DestinationVariable String roomId, @DestinationVariable String memberId) {
         log.trace("SendTemplateMessage 호출");
         log.trace("들어온 메시지(request body)= " + message);
@@ -39,22 +58,76 @@ public class WebSocketController {
 
         messageService.makeMessage(message, roomId, memberId);
 
-        webSocket.convertAndSend(topic, message);
+        webSocket.convertAndSend(topic, message); //구독자에게 메시지 뿌리기
     }
 
-//    @MessageMapping("/ws/{roomId}/message")
-//    @SendTo("/topic/ws/{roomId}") // 메시지를 발행할 토픽 주소
-//    public void sendMessage(@DestinationVariable Long roomId,
-//                            @Payload Message message, Principal principal) {
-//        System.out.println("test22222");
-//        Room room = roomService.findOne(roomId);
-//        String userEmail = principal.getName();
-//        Member member = memberService.findByEmail(userEmail);
-//        Message newMessage = messageService.makeMessage(member, room, message.getContent());
-//        messagingTemplate.convertAndSend("/topic/chat/" + roomId, newMessage);
-//    }
+    @MessageMapping("/heartbeat") // heartbeat 응답
+    public void receiveHeartBeat(@Payload String message, SimpMessageHeaderAccessor accessor) throws JsonProcessingException {
+        log.info("heartbeat 응답 호출");
+        log.info("들어온 메시지(request body)= " + message);
+//        String sessionId = accessor.getSessionId();
+//
+        JsonNode jsonNode = objectMapper.readTree(message);
+        String memberId = jsonNode.get("memberId").asText();
+        log.info("추출된 memberId = " + memberId);
+
+        String memberIdKey = "memberId:"+ memberId;
+        //stringRedisTemplate.opsForHash().put(memberIdKey, "time", LocalDateTime.now().toString());
+        stringRedisTemplate.opsForValue().set(memberIdKey, memberId, 5, TimeUnit.SECONDS);
+
+//        String memberId = payload.
+//        stringRedisTemplate.opsForHash().put(memberId, "time", LocalDateTime.now());
+    }
+
+    @Scheduled(initialDelay = 0, fixedDelay = 3000)
+    public void sendHeartBeat() { //3초마다 각 웹소켓 세션에 대해 heartbeat 메시지 전송
 
 
 
+        Set<String> keys = stringRedisTemplate.keys("memberId:*");
+
+        for (String key : keys) {
+
+
+            // 키에 대한 원하는 작업 수행
+            String memberId = stringRedisTemplate.opsForValue().get(key);
+
+            String topic = "/sub/heartbeat/" + memberId;
+
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("memberId", memberId);
+            payload.put("message", "heartbeat");
+
+            webSocket.convertAndSend(topic, payload);
+        }
+    }
+
+    @Scheduled(initialDelay = 0, fixedDelay = 3000)
+    public void checkHeartBeat() { //3초마다 각 회원의 접속여부 검사
+
+        int memberCount = (int) memberService.memberCount();
+
+        Set<String> keys = stringRedisTemplate.keys("memberId:*");
+
+        Set<String> existingMemberIds = stringRedisTemplate.keys("memberId:*")
+                .stream()
+                .map(memberIdKey -> memberIdKey.substring(memberIdKey.lastIndexOf(":") + 1))
+                .collect(Collectors.toSet());
+
+        Set<Integer> allMemberIds = IntStream.rangeClosed(1, memberCount)
+                .boxed()
+                .collect(Collectors.toSet());
+
+        Set<Integer> missingMemberIds = allMemberIds.stream()
+                .filter(memberId -> !existingMemberIds.contains(memberId.toString()))
+                .collect(Collectors.toSet());
+
+        for (Integer missingMemberId : missingMemberIds) {
+
+            memberService.setMemberInActive(Long.valueOf(missingMemberId));
+
+        }
+
+    }
 
 }

--- a/withSpace/src/main/java/hansung/cse/withSpace/domain/Member.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/domain/Member.java
@@ -74,6 +74,8 @@ public class Member {   //회원
         this.createdAt = now;
         this.updatedAt = now;
 
+        this.status = false;
+
         //스페이스 생성
         MemberSpace memberSpace = new MemberSpace(this);
         this.memberSpace = memberSpace;
@@ -100,5 +102,8 @@ public class Member {   //회원
 
     public void changeUuid(UUID uuid) {
         this.uuid = uuid;
+    }
+    public void setStatus(boolean status) {
+        this.status = status;
     }
 }

--- a/withSpace/src/main/java/hansung/cse/withSpace/repository/member/MemberRepository.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/repository/member/MemberRepository.java
@@ -23,4 +23,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email); //이메일 중복검사시 사용
 
     List<Member> searchMembersByName(String query, int limit);
+
+    long count();
 }

--- a/withSpace/src/main/java/hansung/cse/withSpace/service/MemberService.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/service/MemberService.java
@@ -33,14 +33,14 @@ public class MemberService {
     private final PageService pageService;
 
     @Transactional
-    public void setMemberActive(UUID uuid) {
-        Member member = findByUuid(uuid);
+    public void setMemberActive(Long memberId) {
+        Member member = findOne(memberId);
         member.setStatus(true);
     }
 
     @Transactional
-    public void setMemberInActive(UUID uuid) {
-        Member member = findByUuid(uuid);
+    public void setMemberInActive(Long memberId) {
+        Member member = findOne(memberId);
         member.setStatus(false);
     }
 
@@ -81,6 +81,10 @@ public class MemberService {
         pageService.makePage(memberSpace.getId(), pageCreateRequestDto);
 
         return member.getId();
+    }
+
+    public long memberCount() {
+        return memberRepository.count();
     }
 
 

--- a/withSpace/src/main/java/hansung/cse/withSpace/service/MemberService.java
+++ b/withSpace/src/main/java/hansung/cse/withSpace/service/MemberService.java
@@ -32,11 +32,18 @@ public class MemberService {
     private final ScheduleService scheduleService;
     private final PageService pageService;
 
-//    private final SpaceRepository spaceRepository;
-//    private final ScheduleRepository scheduleRepository;
-//    private final PageRepository pageRepository;
+    @Transactional
+    public void setMemberActive(UUID uuid) {
+        Member member = findByUuid(uuid);
+        member.setStatus(true);
+    }
 
-    //final private PasswordEncoder passwordEncoder; //비밀번호 암호화
+    @Transactional
+    public void setMemberInActive(UUID uuid) {
+        Member member = findByUuid(uuid);
+        member.setStatus(false);
+    }
+
 
     public Member findOne(Long memberId) {
         return memberRepository.findById(memberId)


### PR DESCRIPTION
> memberId를 키값으로 시간을 저장 <  
 웹소켓 최초 연결시  
1. 웹소켓 연결시 토큰에서부터 UUID를 뽑아서 status를 true로 변경  
2. memberId:{memberId}를 key로 memberId를 저장  
 * 성능을 위해 memberId Key로 저장할 데이터들은 유효기간을 5초로 줍니다   
  
그 이후  
1. 클라이언트에게 3초에 한번씩 heartbeat를 보냄  
	1-1) redis에서 memberId Key를 반복문으로 돌면서 memberId Key의 값인 memberId를 뽑아서 메시지를 보냄  
	1-2) 이를 위해 client는 /sub/heartbeat/[본인memberId] 를 구독해야함  
	1-3) 클라이언트는 이걸 받으면 /pub/heartbeat로, 본인의 memberId를 본문에 포함해서 보냄  
2. heartbeat의 응답이 오면 해당 마찬가지로 redis에 memberId를 저장해줌 

a. 3초에 한번씩 redis에서 member의 응답이 있었는지 확인  
b. 응답이 없었다면 status를 false로 변경  


++ 이를 위해 클라이언트에서 다음 코드 필요   
```
  const connect = () => {
    const token = localStorage.getItem("withspace_token");
    client.current = new Client({
      brokerURL: "ws://localhost:8080/ws",
      connectHeaders: {
        Authorization: `Bearer ${token}`,
      },
      debug: () => {},
      onConnect: () => {
        subscribe();

        **subscribeHeartbeat();**
        
      },
    });
    client.current.activate();
  };

...

  const subscribeHeartbeat = () => {
    const heartbeatTopic = `/sub/heartbeat/${userInfo.id}`;
    client.current?.subscribe(heartbeatTopic, (data) => {
        client.current?.publish({
          destination: "/pub/heartbeat",
          body: JSON.stringify({
            memberId: userInfo.id
          }),
        });
    });
  };


```


